### PR TITLE
Increase starship command timeout

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,3 +1,5 @@
+command_timeout = 1000
+
 [character]
 success_symbol = "❯"
 vicmd_symbol = "❮"


### PR DESCRIPTION
Increased command timeout needed for Starship to play nicely with iTerm2 AutoLaunch Python scripts. See https://starship.rs/faq/#why-do-i-see-executing-command-timed-out-warnings